### PR TITLE
fix: drop nonexistent prefix/ path in env hook

### DIFF
--- a/hooks/backend_exec_env.lua
+++ b/hooks/backend_exec_env.lua
@@ -6,16 +6,14 @@ function PLUGIN:BackendExecEnv(ctx)
 
     local file = require("file")
 
-    -- zerobrew installs to {root}/prefix/ with bin/, lib/, include/, etc.
-    local prefix_path = file.join_path(install_path, "prefix")
-    local bin_path = file.join_path(prefix_path, "bin")
+    -- zerobrew installs directly under {install_path} (bin/, lib/, include/, ...)
+    local bin_path = file.join_path(install_path, "bin")
 
     local env_vars = {
         { key = "PATH", value = bin_path },
     }
 
-    -- Add lib paths for tools that need dynamic libraries
-    local lib_path = file.join_path(prefix_path, "lib")
+    local lib_path = file.join_path(install_path, "lib")
 
     if RUNTIME.osType == "Darwin" then
         table.insert(env_vars, { key = "DYLD_LIBRARY_PATH", value = lib_path })
@@ -23,13 +21,11 @@ function PLUGIN:BackendExecEnv(ctx)
         table.insert(env_vars, { key = "LD_LIBRARY_PATH", value = lib_path })
     end
 
-    -- Add include path for development headers
-    local include_path = file.join_path(prefix_path, "include")
+    local include_path = file.join_path(install_path, "include")
     table.insert(env_vars, { key = "C_INCLUDE_PATH", value = include_path })
     table.insert(env_vars, { key = "CPLUS_INCLUDE_PATH", value = include_path })
 
-    -- Add pkg-config path
-    local pkgconfig_path = file.join_path(prefix_path, "lib", "pkgconfig")
+    local pkgconfig_path = file.join_path(install_path, "lib", "pkgconfig")
     table.insert(env_vars, { key = "PKG_CONFIG_PATH", value = pkgconfig_path })
 
     return {


### PR DESCRIPTION
## Summary

The env hook joined a `prefix/` segment that `zb` never creates, so `PATH`, `DYLD_LIBRARY_PATH`, `C_INCLUDE_PATH`, and `PKG_CONFIG_PATH` all pointed at empty directories.

`zb --root <path> install <formula>` lays down a flat Homebrew-style tree directly under `<path>`:

```
~/.local/share/mise/installs/zerobrew-pv/latest/
├── bin/         # actual binaries / symlinks live here
├── Cellar/
├── lib/
├── include/
├── opt/
├── store/
└── ...
```

There is no `prefix/` subdirectory, so `mise which <tool>` failed and shims did not resolve. Fix is to drop the `prefix` join.

## Repro (before fix)

```sh
mise install zerobrew:pv@latest
mise which pv
# mise ERROR pv is not a mise bin. Perhaps you need to install it first.

ls ~/.local/share/mise/installs/zerobrew-pv/latest/bin/pv     # exists
ls ~/.local/share/mise/installs/zerobrew-pv/latest/prefix/    # does NOT exist
```

The same root cause produced a confusing `dyld[…]: Library not loaded` error for formulae with dynamic-library deps (e.g. `luacheck` → `liblua.dylib`), because `DYLD_LIBRARY_PATH` was empty.

## After fix

Verified `pv`, `luacheck`, and `tree` all install and run via `mise install zerobrew:<formula>` followed by `mise reshim` on macOS arm64.

## Test plan

- [x] `mise install zerobrew:pv@latest` → `pv --version` works via mise shim
- [x] `mise install zerobrew:luacheck@latest` → `luacheck --version` resolves `liblua.dylib`
- [x] `mise install zerobrew:tree@latest` → `tree --version` works
